### PR TITLE
Bug 2028484: CSI driver's livenessprobe does not respect operator's loglevel

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -83,6 +83,7 @@ spec:
               name: socket-dir
         - args:
             - --csi-address=/csi/csi.sock
+            - --v=${LOG_LEVEL}
           image: ${LIVENESS_PROBE_IMAGE}
           name: liveness-probe
           securityContext:

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -137,6 +137,7 @@ spec:
               readOnly: true
         - args:
             - --csi-address=/csi/csi.sock
+            - --v=${LOG_LEVEL}
           image: ${LIVENESS_PROBE_IMAGE}
           name: liveness-probe
           securityContext:


### PR DESCRIPTION
When log level is changed in clustercsidriver it needs to propagate to a liveness probe container as well through a value passed to --v argument.