### PR TITLE
Bug 2033111: IBM VPC operator library bump removed global CLI args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS builder
-WORKDIR /go/src/github.com/IBM/ibm-vpc-block-csi-driver-operator
+WORKDIR /go/src/github.com/openshift/ibm-vpc-block-csi-driver-operator
 COPY . .
 RUN make
 
 FROM registry.ci.openshift.org/ocp/4.10:base
-COPY --from=builder /go/src/github.com/IBM/ibm-vpc-block-csi-driver-operator/ibm-vpc-block-csi-driver-operator /usr/bin
+COPY --from=builder /go/src/github.com/openshift/ibm-vpc-block-csi-driver-operator/ibm-vpc-block-csi-driver-operator /usr/bin
 COPY manifests /manifests
 ENTRYPOINT ["/usr/bin/ibm-vpc-block-csi-driver-operator"]
 LABEL io.k8s.display-name="OpenShift IBM VPC Block CSI Driver Operator" \

--- a/assets/storageclass/vpc-block-10iopsTier-StorageClass.yaml
+++ b/assets/storageclass/vpc-block-10iopsTier-StorageClass.yaml
@@ -22,4 +22,4 @@ parameters:
   zone: ""
 provisioner: vpc.block.csi.ibm.io
 reclaimPolicy: Delete
-
+volumeBindingMode: WaitForFirstConsumer

--- a/assets/storageclass/vpc-block-5iopsTier-StorageClass.yaml
+++ b/assets/storageclass/vpc-block-5iopsTier-StorageClass.yaml
@@ -20,3 +20,4 @@ parameters:
   zone: ""
 provisioner: vpc.block.csi.ibm.io
 reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/assets/storageclass/vpc-block-custom-StorageClass.yaml
+++ b/assets/storageclass/vpc-block-custom-StorageClass.yaml
@@ -28,3 +28,4 @@ parameters:
   zone: ""
 provisioner: vpc.block.csi.ibm.io
 reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/cmd/ibm-vpc-block-csi-driver-operator/main.go
+++ b/cmd/ibm-vpc-block-csi-driver-operator/main.go
@@ -2,38 +2,21 @@ package main
 
 import (
 	"context"
-	"flag"
-	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
-	k8sflag "k8s.io/component-base/cli/flag"
-	"k8s.io/component-base/logs"
+	"k8s.io/component-base/cli"
 
+	"github.com/openshift/ibm-vpc-block-csi-driver-operator/pkg/operator"
+	"github.com/openshift/ibm-vpc-block-csi-driver-operator/pkg/version"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
-
-	"github.com/IBM/ibm-vpc-block-csi-driver-operator/pkg/operator"
-	"github.com/IBM/ibm-vpc-block-csi-driver-operator/pkg/version"
 )
 
 func main() {
-	rand.Seed(time.Now().UTC().UnixNano())
-
-	pflag.CommandLine.SetNormalizeFunc(k8sflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-
-	logs.InitLogs()
-	defer logs.FlushLogs()
-
 	command := NewOperatorCommand()
-	if err := command.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
-	}
+	code := cli.Run(command)
+	os.Exit(code)
 }
 
 func NewOperatorCommand() *cobra.Command {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/IBM/ibm-vpc-block-csi-driver-operator
+module github.com/openshift/ibm-vpc-block-csi-driver-operator
 
 go 1.16
 
@@ -10,7 +10,6 @@ require (
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
 	github.com/openshift/library-go v0.0.0-20211214183058-58531ccbde67
 	github.com/spf13/cobra v1.2.1
-	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.23.0
 	k8s.io/apimachinery v0.23.0

--- a/pkg/controller/secret/secretsync.go
+++ b/pkg/controller/secret/secretsync.go
@@ -9,6 +9,7 @@ import (
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/ibm-vpc-block-csi-driver-operator/pkg/util"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -19,8 +20,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
-
-	"github.com/IBM/ibm-vpc-block-csi-driver-operator/pkg/util"
 )
 
 // This SecretSyncController translates Secret provided by cloud-credential-operator into

--- a/pkg/controller/secret/secretsync_test.go
+++ b/pkg/controller/secret/secretsync_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/IBM/ibm-vpc-block-csi-driver-operator/pkg/util"
+	"github.com/openshift/ibm-vpc-block-csi-driver-operator/pkg/util"
 	k8v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -3,29 +3,30 @@ package operator
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"k8s.io/client-go/dynamic"
-	"time"
+
+	"os"
+	"strings"
 
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
-	"os"
-	"strings"
 
 	opv1 "github.com/openshift/api/operator/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+	"github.com/openshift/ibm-vpc-block-csi-driver-operator/assets"
+	"github.com/openshift/ibm-vpc-block-csi-driver-operator/pkg/controller/secret"
+	"github.com/openshift/ibm-vpc-block-csi-driver-operator/pkg/util"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/operator/csi/csicontrollerset"
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller"
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivernodeservicecontroller"
 	goc "github.com/openshift/library-go/pkg/operator/genericoperatorclient"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
-
-	"github.com/IBM/ibm-vpc-block-csi-driver-operator/assets"
-	"github.com/IBM/ibm-vpc-block-csi-driver-operator/pkg/controller/secret"
-	"github.com/IBM/ibm-vpc-block-csi-driver-operator/pkg/util"
 )
 
 func readFileAndReplace(name string) ([]byte, error) {

--- a/vendor/k8s.io/component-base/cli/OWNERS
+++ b/vendor/k8s.io/component-base/cli/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Currently assigned cli to sig-cli since:
+# (a) its literally named "cli"
+# (b) flags are the bread-and-butter of cli tools.
+
+approvers:
+- sig-cli-maintainers
+reviewers:
+- sig-cli
+labels:
+- sig/cli

--- a/vendor/k8s.io/component-base/cli/run.go
+++ b/vendor/k8s.io/component-base/cli/run.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/logs"
+	"k8s.io/klog/v2"
+)
+
+// Run provides the common boilerplate code around executing a cobra command.
+// For example, it ensures that logging is set up properly. Logging
+// flags get added to the command line if not added already. Flags get normalized
+// so that help texts show them with hyphens. Underscores are accepted
+// as alternative for the command parameters.
+func Run(cmd *cobra.Command) int {
+	rand.Seed(time.Now().UnixNano())
+	defer logs.FlushLogs()
+
+	cmd.SetGlobalNormalizationFunc(cliflag.WordSepNormalizeFunc)
+
+	// When error printing is enabled for the Cobra command, a flag parse
+	// error gets printed first, then optionally the often long usage
+	// text. This is very unreadable in a console because the last few
+	// lines that will be visible on screen don't include the error.
+	//
+	// The recommendation from #sig-cli was to print the usage text, then
+	// the error. We implement this consistently for all commands here.
+	// However, we don't want to print the usage text when command
+	// execution fails for other reasons than parsing. We detect this via
+	// the FlagParseError callback.
+	//
+	// A variable is used instead of wrapping the error with a special
+	// error type because the variable is simpler and less fragile: the
+	// original FlagErrorFunc might replace the wrapped error.
+	parsingFailed := false
+	if cmd.SilenceUsage {
+		// Some commands, like kubectl, already deal with this themselves.
+		// We don't change the behavior for those and just track whether
+		// parsing failed for the error output below.
+		flagErrorFunc := cmd.FlagErrorFunc()
+		cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
+			parsingFailed = true
+			return flagErrorFunc(c, err)
+		})
+	} else {
+		cmd.SilenceUsage = true
+		cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
+			parsingFailed = true
+
+			// Re-enable usage printing.
+			c.SilenceUsage = false
+			return err
+		})
+	}
+
+	// In all cases error printing is done below.
+	cmd.SilenceErrors = true
+
+	// This is idempotent.
+	logs.AddFlags(cmd.PersistentFlags())
+
+	// Inject logs.InitLogs after command line parsing into one of the
+	// PersistentPre* functions.
+	switch {
+	case cmd.PersistentPreRun != nil:
+		pre := cmd.PersistentPreRun
+		cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+			logs.InitLogs()
+			pre(cmd, args)
+		}
+	case cmd.PersistentPreRunE != nil:
+		pre := cmd.PersistentPreRunE
+		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+			logs.InitLogs()
+			return pre(cmd, args)
+		}
+	default:
+		cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+			logs.InitLogs()
+		}
+	}
+
+	if err := cmd.Execute(); err != nil {
+		// If the error is about flag parsing, then printing that error
+		// with the decoration that klog would add ("E0923
+		// 23:02:03.219216 4168816 run.go:61] unknown shorthand flag")
+		// is less readable. Using klog.Fatal is even worse because it
+		// dumps a stack trace that isn't about the error.
+		//
+		// But if it is some other error encountered at runtime, then
+		// we want to log it as error.
+		//
+		// We can distinguish these two cases depending on whether
+		// our FlagErrorFunc above was called.
+		if parsingFailed {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		} else {
+			klog.ErrorS(err, "command failed")
+		}
+		return 1
+	}
+	return 0
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -274,7 +274,6 @@ github.com/sirupsen/logrus
 ## explicit
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
-## explicit
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.7.0
 ## explicit
@@ -1041,6 +1040,7 @@ k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
 # k8s.io/component-base v0.23.0
 ## explicit
+k8s.io/component-base/cli
 k8s.io/component-base/cli/flag
 k8s.io/component-base/config
 k8s.io/component-base/config/v1alpha1


### PR DESCRIPTION
This includes commits for 2 bug fixes:

- [Bug 2034528](https://bugzilla.redhat.com/show_bug.cgi?id=2034528): [IBM VPC] volumeBindingMode should be WaitForFirstConsumer
- [Bug 2033111](https://bugzilla.redhat.com/show_bug.cgi?id=2033111): IBM VPC operator library bump removed global CLI args

/cc @openshift/storage 