### PR TITLE
Bug 2037167: Some log level in ibm-vpc-block-csi-controller are hard code

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - args:
-            - --v=5
+            - --v=${LOG_LEVEL}
             - --csi-address=/csi/csi.sock
             - --timeout=900s
           name: csi-resizer
@@ -38,7 +38,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - args:
-            - --v=5
+            - --v=${LOG_LEVEL}
             - --csi-address=$(ADDRESS)
             - --timeout=600s
             - --feature-gates=Topology=true
@@ -62,7 +62,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - args:
-            - --v=5
+            - --v=${LOG_LEVEL}
             - --csi-address=/csi/csi.sock
             - --timeout=900s
           image: ${ATTACHER_IMAGE}
@@ -100,7 +100,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - args:
-            - --v=5
+            - --v=${LOG_LEVEL}
             - --endpoint=$(CSI_ENDPOINT)
             - --lock_enabled=false
           env:

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -41,7 +41,7 @@ spec:
               name: customer-auth
       containers:
         - args:
-            - --v=5
+            - --v=${LOG_LEVEL}
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REGISTRATION_SOCK)
           env:
@@ -80,7 +80,7 @@ spec:
             - mountPath: /registration
               name: registration-dir
         - args:
-            - --v=5
+            - --v=${LOG_LEVEL}
             - --endpoint=unix:/csi/csi.sock
           env:
             - name: KUBE_NODE_NAME


### PR DESCRIPTION
The log levels should not be hard coded, use a variable in both node and controller deployments.