### PR TITLE
Bug 2044248: Always apply fsGroup to volumes

### DIFF
--- a/assets/csidriver.yaml
+++ b/assets/csidriver.yaml
@@ -7,3 +7,4 @@ spec:
   podInfoOnMount: true
   volumeLifecycleModes:
     - Persistent
+  fsGroupPolicy: "File"


### PR DESCRIPTION
Don't use the default heuristics, it's wrong when there is no `fsType` in a StorageClass / PV.

cc @openshift/storage 