### PR TITLE
Bug 2041441: Provision volume with size 3000Gi even if sizeRange: '[1…

### DIFF
--- a/assets/storageclass/vpc-block-10iopsTier-StorageClass.yaml
+++ b/assets/storageclass/vpc-block-10iopsTier-StorageClass.yaml
@@ -9,15 +9,12 @@ metadata:
     razee/force-apply: "true"
   name: ibmc-vpc-block-10iops-tier
 parameters:
-  billingType: hourly
-  classVersion: "1"
   csi.storage.k8s.io/fstype: ext4
   encrypted: "false"
   encryptionKey: ""
   profile: 10iops-tier
   region: ""
   resourceGroup: ""
-  sizeRange: '[10-2000]GiB'
   tags: ""
   zone: ""
 provisioner: vpc.block.csi.ibm.io

--- a/assets/storageclass/vpc-block-5iopsTier-StorageClass.yaml
+++ b/assets/storageclass/vpc-block-5iopsTier-StorageClass.yaml
@@ -7,15 +7,12 @@ metadata:
     razee/force-apply: "true"
   name: ibmc-vpc-block-5iops-tier
 parameters:
-  billingType: hourly
-  classVersion: "1"
   csi.storage.k8s.io/fstype: ext4
   encrypted: "false"
   encryptionKey: ""
   profile: 5iops-tier
   region: ""
   resourceGroup: ""
-  sizeRange: '[10-2000]GiB'
   tags: ""
   zone: ""
 provisioner: vpc.block.csi.ibm.io

--- a/assets/storageclass/vpc-block-custom-StorageClass.yaml
+++ b/assets/storageclass/vpc-block-custom-StorageClass.yaml
@@ -7,8 +7,6 @@ metadata:
     razee/force-apply: "true"
   name: ibmc-vpc-block-custom
 parameters:
-  billingType: hourly
-  classVersion: "1"
   csi.storage.k8s.io/fstype: ext4
   encrypted: "false"
   encryptionKey: ""
@@ -16,14 +14,6 @@ parameters:
   profile: custom
   region: ""
   resourceGroup: ""
-  sizeIOPSRange: |-
-    [10-39]GiB:[100-1000]
-    [40-79]GiB:[100-2000]
-    [80-99]GiB:[100-4000]
-    [100-499]GiB:[100-6000]
-    [500-999]GiB:[100-10000]
-    [1000-1999]GiB:[100-20000]
-  sizeRange: '[10-2000]GiB'
   tags: ""
   zone: ""
 provisioner: vpc.block.csi.ibm.io


### PR DESCRIPTION
…0-2000]GiB' in storageclass on IBM cloud
https://bugzilla.redhat.com/show_bug.cgi?id=2041441
This removes the parameters that are not used by the driver:
https://github.com/openshift/ibm-vpc-block-csi-driver/blob/d54e3706bb8b38447800aa91632a946eb6c990ec/pkg/ibmcsidriver/controller_helper.go#L152-L184
/cc @openshift/storage 