### PR TITLE
Bug 2048824: IBMCloud: Add critical spec to driver daemonset

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -13,6 +13,10 @@ spec:
   selector:
     matchLabels:
       app: ibm-vpc-block-csi-driver
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
   template:
     metadata:
       labels:
@@ -25,9 +29,6 @@ spec:
             privileged: false
             allowPrivilegeEscalation: false
           resources:
-            limits:
-              cpu: 12m
-              memory: 24Mi
             requests:
               cpu: 3m
               memory: 6Mi
@@ -71,9 +72,6 @@ spec:
             runAsUser: 0
             privileged: false
           resources:
-            limits:
-              cpu: 100m
-              memory: 100Mi
             requests:
               cpu: 10m
               memory: 20Mi
@@ -109,9 +107,6 @@ spec:
               name: healthz
               protocol: TCP
           resources:
-            limits:
-              cpu: 200m
-              memory: 250Mi
             requests:
               cpu: 20m
               memory: 50Mi
@@ -148,9 +143,6 @@ spec:
             runAsUser: 0
             privileged: false
           resources:
-            limits:
-              cpu: 50m
-              memory: 50Mi
             requests:
               cpu: 5m
               memory: 10Mi
@@ -158,6 +150,7 @@ spec:
             - mountPath: /csi
               name: plugin-dir
       serviceAccountName: ibm-vpc-block-node-sa
+      priorityClassName: system-node-critical
       tolerations:
         - operator: Exists
       volumes:


### PR DESCRIPTION
Add some critical settings to the driver daemonset template,
including priority class and update strategy. Remove the resource
limits for pods. All per OCP Conformance test expectations for
managed pods.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2048824