### PR TITLE
[don't merge] Allow user to define their own default class

### DIFF
--- a/assets/storageclass/vpc-block-10iopsTier-StorageClass.yaml
+++ b/assets/storageclass/vpc-block-10iopsTier-StorageClass.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
   labels:
-    addonmanager.kubernetes.io/mode: Reconcile
+    addonmanager.kubernetes.io/mode: EnsureExists
     app: ibm-vpc-block-csi-driver
     razee/force-apply: "true"
   name: ibmc-vpc-block-10iops-tier


### PR DESCRIPTION
We can merge this PR if we want user to define their own default class

Steps for user would be:

1- Remove `storageclass.kubernetes.io/is-default-class: "true"` from ibmc-vpc-block-10iops-tier storage class
2- User can create their own default class after that