### PR TITLE
Changes to fetch region from node

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -108,6 +108,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           envFrom:
             - configMapRef:
                 name: ibm-vpc-block-csi-configmap


### PR DESCRIPTION
In [v4.3 Release](https://github.com/kubernetes-sigs/ibm-vpc-block-csi-driver/releases/tag/v4.3.0), few bugs are fixed and for that we are fetching region details from node. This PR is relevant to v4.3 , to get the node name from environment variable in iks-vpc-block-driver container