### PR TITLE
STOR-1060: Update deployment files for snapshot support

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -31,7 +31,7 @@ spec:
             - --timeout=900s
           name: csi-resizer
           image: ${RESIZER_IMAGE}
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
@@ -51,10 +51,10 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
           image: ${PROVISIONER_IMAGE}
+          imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
-          imagePullPolicy: Always
           name: csi-provisioner
           resources:
             requests:
@@ -68,10 +68,10 @@ spec:
             - --csi-address=/csi/csi.sock
             - --timeout=900s
           image: ${ATTACHER_IMAGE}
+          imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
-          imagePullPolicy: Always
           name: csi-attacher
           resources:
             requests:
@@ -84,6 +84,7 @@ spec:
             - --csi-address=/csi/csi.sock
             - --v=${LOG_LEVEL}
           image: ${LIVENESS_PROBE_IMAGE}
+          imagePullPolicy: IfNotPresent
           name: liveness-probe
           securityContext:
             privileged: false
@@ -92,6 +93,24 @@ spec:
             requests:
               cpu: 5m
               memory: 10Mi
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: csi-snapshotter
+          image: ${SNAPSHOTTER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=${LOG_LEVEL}
+            - --csi-address=/csi/csi.sock
+            - --timeout=900s
+            - --leader-election=false
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -117,7 +136,7 @@ spec:
             - configMapRef:
                 name: ibm-vpc-block-csi-configmap
           image: ${DRIVER_IMAGE}
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -24,7 +24,6 @@ spec:
     spec:
       initContainers:
         - name: vpc-node-label-updater
-          imagePullPolicy: Always
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
@@ -40,6 +39,7 @@ spec:
             - name: SECRET_CONFIG_PATH
               value: /etc/storage_ibmc
           image: ${NODE_LABEL_IMAGE}
+          imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/storage_ibmc
               name: customer-auth
@@ -58,7 +58,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           image: ${NODE_DRIVER_REGISTRAR_IMAGE}
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
               exec:
@@ -92,7 +92,7 @@ spec:
             - configMapRef:
                 name: ibm-vpc-block-csi-configmap
           image: ${DRIVER_IMAGE}
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 5
             httpGet:
@@ -137,6 +137,7 @@ spec:
             - --csi-address=/csi/csi.sock
             - --v=${LOG_LEVEL}
           image: ${LIVENESS_PROBE_IMAGE}
+          imagePullPolicy: IfNotPresent
           name: liveness-probe
           securityContext:
             runAsNonRoot: false

--- a/assets/rbac/snapshotter_binding.yaml
+++ b/assets/rbac/snapshotter_binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vpc-block-driver-snapshotter-binding
+subjects:
+  - kind: ServiceAccount
+    name: ibm-vpc-block-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: vpc-block-driver-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io

--- a/assets/rbac/snapshotter_role.yaml
+++ b/assets/rbac/snapshotter_role.yaml
@@ -1,0 +1,20 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vpc-block-driver-snapshotter-role
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]

--- a/assets/volumesnapshotclass.yaml
+++ b/assets/volumesnapshotclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: vpc-block-snapshot
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: vpc.block.csi.ibm.io
+deletionPolicy: Delete

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"fmt"
+
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"k8s.io/client-go/dynamic"
 
@@ -82,6 +83,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			"csidriver.yaml",
 			"node_sa.yaml",
 			"cabundle_cm.yaml",
+			"volumesnapshotclass.yaml",
 			"rbac/attacher_role.yaml",
 			"rbac/attacher_rolebinding.yaml",
 			"rbac/provisioner_binding.yaml",
@@ -92,6 +94,8 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			"rbac/resizer_rolebinding.yaml",
 			"rbac/initcontainer_role.yaml",
 			"rbac/initcontainer_rolebinding.yaml",
+			"rbac/snapshotter_binding.yaml",
+			"rbac/snapshotter_role.yaml",
 			"storageclass/vpc-block-5iopsTier-StorageClass.yaml",
 			"storageclass/vpc-block-custom-StorageClass.yaml",
 		},


### PR DESCRIPTION
https://issues.redhat.com/browse/STOR-1060
This adds snapshot support to the deployment files after the driver is updated to v5.0.0 with snapshot support.
/hold for https://github.com/openshift/ibm-vpc-block-csi-driver/pull/26
/cc @openshift/storage @chao007
