### PR TITLE
STOR-1078: Add hostPaths necessary for SELinux mounts

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -133,6 +133,8 @@ spec:
             - mountPath: /etc/storage_ibmc
               name: customer-auth
               readOnly: true
+            - name: etc-selinux
+              mountPath: /etc/selinux
         - args:
             - --csi-address=/csi/csi.sock
             - --v=${LOG_LEVEL}
@@ -190,3 +192,7 @@ spec:
         - name: customer-auth
           secret:
             secretName: storage-secret-store
+        - name: etc-selinux
+          hostPath:
+            path: /etc/selinux
+            type: DirectoryOrCreate


### PR DESCRIPTION
To support "mount -o context=XYZ", /etc/selinux and /sys/fs/selinux from the host must be present in the CSI driver container.

This PR is different than others, the driver already has `/sys` mounted from the host.

cc @openshift/storage 