### PR TITLE
Bug 2106736: Add multiplePVsSameID capability

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -28,3 +28,4 @@ DriverInfo:
     nodeExpansion: true
     volumeLimits: false
     topology: true
+    multiplePVsSameID: true


### PR DESCRIPTION
This CSI driver can handle multiple PVs that have the same VolumeHandle used on the same node.

cc @openshift/storage