### PR TITLE
OCPBUGS-8683: Add management workloads annotations

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -23,6 +23,8 @@ spec:
     metadata:
       labels:
         app: ibm-vpc-block-csi-driver
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
         - args:

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -21,6 +21,8 @@ spec:
     metadata:
       labels:
         app: ibm-vpc-block-csi-driver
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       initContainers:
         - name: vpc-node-label-updater


### PR DESCRIPTION
To support the workload partitioning we need to add the required annotations (openshift/enhancements#703).