### PR TITLE
WIP: DO_NOT_MERGE: check if RBAC Cluster role for attacher needs for …

### DIFF
--- a/assets/rbac/attacher_role.yaml
+++ b/assets/rbac/attacher_role.yaml
@@ -25,9 +25,9 @@ rules:
       - list
       - watch
   - apiGroups:
-      - csi.storage.k8s.io
+      - storage.k8s.io
     resources:
-      - csinodeinfos
+      - csinodes
     verbs:
       - get
       - list


### PR DESCRIPTION
…"csinodeinfos"

All other operators wants "csinodes" instead. The assumption is that we have "csinodeinfos" here by *mistake*.