### PR TITLE
WIP: DO_NOT_MERGE: test `ci/prow/e2e-ibmcloud-csi-extended`

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -1,5 +1,6 @@
 package operator
 
+// DUMMY CHANGE
 import (
 	"context"
 	"fmt"


### PR DESCRIPTION
Let's check if it's perma-failing with:
```
: OCP-48934:chaoyang:[CSI-Driver] [Snapshot] [Raw Block] provisioning should provision storage with snapshot data source larger than original volume expand_less	1m28s
{  fail [github.com/openshift/openshift-tests-private/test/extended/storage/workload_utils.go:385]: Unexpected error:
    <*util.ExitError | 0xc002f2aed0>:
    exit status 1
    {
        Cmd: "oc --kubeconfig=/tmp/configfile119710445 exec -n e2e-test-storage-general-csi-bx6zp mypod-x2ofs44d -- /bin/sh -c /bin/dd  if=/dev/null of=/dev/dblock bs=512 count=1",
        StdErr: "/bin/dd: failed to open '/dev/dblock': Permission denied\ncommand terminated with exit code 1",
```