### PR TITLE
[release-4.13] OCPBUGS-16250: Add management workloads annotations

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -23,6 +23,8 @@ spec:
     metadata:
       labels:
         app: ibm-vpc-block-csi-driver
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
         - args:

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -21,6 +21,8 @@ spec:
     metadata:
       labels:
         app: ibm-vpc-block-csi-driver
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       initContainers:
         - name: vpc-node-label-updater


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/ibm-vpc-block-csi-driver-operator/pull/53 , fix the OCPBUGS-16250.