### PR TITLE
OCPBUGS-18105: [IBM VPC] failed provisioning volume in proxy cluster

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -150,7 +150,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 3
-          name: iks-vpc-block-driver
+          name: csi-driver
           ports:
             - containerPort: 9808
               name: healthz

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -103,7 +103,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 3
-          name: iks-vpc-block-node-driver
+          name: csi-driver
           ports:
             - containerPort: 9808
               name: healthz


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-18105

Most (or all?) of our other CSI drivers use `csi-driver` as the container name. So I'm changing this one to match all the others as well as the [inject-proxy rule](https://github.com/openshift/ibm-vpc-block-csi-driver-operator/blob/62408833a2857b7cd1cb5561bc86e531f53f7081/assets/controller.yaml#L10-L11) that we already have.

/cc @openshift/storage @duanwei33
