### PR TITLE
OCPBUGS-22924: Removing unncessary imagePullSecrets

### DIFF
--- a/assets/controller_sa.yaml
+++ b/assets/controller_sa.yaml
@@ -1,9 +1,4 @@
 apiVersion: v1
-imagePullSecrets:
-  - name: bluemix-default-secret
-  - name: bluemix-default-secret-regional
-  - name: bluemix-default-secret-international
-  - name: icr-io-secret
 kind: ServiceAccount
 metadata:
   labels:

--- a/assets/node_sa.yaml
+++ b/assets/node_sa.yaml
@@ -1,9 +1,4 @@
 apiVersion: v1
-imagePullSecrets:
-  - name: bluemix-default-secret
-  - name: bluemix-default-secret-regional
-  - name: bluemix-default-secret-international
-  - name: icr-io-secret
 kind: ServiceAccount
 metadata:
   labels:


### PR DESCRIPTION
The following failures are seen during 4.15 OCP Conformance testing.
```
event happened 29 times, something is wrong: ns/openshift-cluster-csi-drivers pod/ibm-vpc-block-csi-node-6jz5b node/ci-op-yv1idktj-52953-cz9r6-worker-3-2dzfq hmsg/99d84ba4c3 - pathological/true reason/FailedToRetrieveImagePullSecret Unable to retrieve some image pull secrets (bluemix-default-secret, bluemix-default-secret-regional, bluemix-default-secret-international, icr-io-secret); attempting to pull the image may not succeed. From: 17:18:02Z To: 17:18:03Z result=reject 
event happened 36 times, something is wrong: ns/openshift-cluster-csi-drivers pod/ibm-vpc-block-csi-node-ljsc9 node/ci-op-yv1idktj-52953-cz9r6-master-0 hmsg/99d84ba4c3 - pathological/true reason/FailedToRetrieveImagePullSecret Unable to retrieve some image pull secrets (bluemix-default-secret, bluemix-default-secret-regional, bluemix-default-secret-international, icr-io-secret); attempting to pull the image may not succeed. From: 17:18:26Z To: 17:18:27Z result=reject 
event happened 33 times, something is wrong: ns/openshift-cluster-csi-drivers pod/ibm-vpc-block-csi-node-6jz5b node/ci-op-yv1idktj-52953-cz9r6-worker-3-2dzfq hmsg/99d84ba4c3 - pathological/true reason/FailedToRetrieveImagePullSecret Unable to retrieve some image pull secrets (bluemix-default-secret, bluemix-default-secret-regional, bluemix-default-secret-international, icr-io-secret); attempting to pull the image may not succeed. From: 17:23:20Z To: 17:23:21Z result=reject 
```
Hence the removal of these imagePullSecrets is necesary. 