### PR TITLE
OCPBUGS-29247: ibm-vpc-block-csi-driver is missing sidecar metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ export NODE_DRIVER_REGISTRAR_IMAGE=registry.k8s.io/sig-storage/csi-node-driver-r
 export LIVENESS_PROBE_IMAGE=registry.k8s.io/sig-storage/livenessprobe:v2.9.0
 export RESIZER_IMAGE=registry.k8s.io/sig-storage/csi-resizer:v1.7.0
 export SNAPSHOTTER_IMAGE=registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1
+export KUBE_RBAC_PROXY_IMAGE=quay.io/openshift/origin-kube-rbac-proxy:latest
 
 # Run the operator via CLI
 ./ibm-vpc-block-csi-driver-operator start --kubeconfig $MY_KUBECONFIG --namespace openshift-cluster-csi-drivers

--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -27,13 +27,13 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
-        - args:
+        - name: csi-resizer
+          image: ${RESIZER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
             - --v=${LOG_LEVEL}
             - --csi-address=/csi/csi.sock
             - --timeout=900s
-          name: csi-resizer
-          image: ${RESIZER_IMAGE}
-          imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
@@ -44,7 +44,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-        - args:
+        - name: csi-provisioner
+          image: ${PROVISIONER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
             - --v=${LOG_LEVEL}
             - --csi-address=$(ADDRESS)
             - --timeout=600s
@@ -52,12 +55,9 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: ${PROVISIONER_IMAGE}
-          imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
-          name: csi-provisioner
           resources:
             requests:
               cpu: 10m
@@ -65,16 +65,16 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-        - args:
+        - name: csi-attacher
+          image: ${ATTACHER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
             - --v=${LOG_LEVEL}
             - --csi-address=/csi/csi.sock
             - --timeout=900s
-          image: ${ATTACHER_IMAGE}
-          imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
-          name: csi-attacher
           resources:
             requests:
               cpu: 10m
@@ -82,12 +82,12 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-        - args:
-            - --csi-address=/csi/csi.sock
-            - --v=${LOG_LEVEL}
+        - name: liveness-probe
           image: ${LIVENESS_PROBE_IMAGE}
           imagePullPolicy: IfNotPresent
-          name: liveness-probe
+          args:
+            - --csi-address=/csi/csi.sock
+            - --v=${LOG_LEVEL}
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
@@ -116,7 +116,10 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-        - args:
+        - name: csi-driver
+          image: ${DRIVER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
             - --v=${LOG_LEVEL}
             - --endpoint=$(CSI_ENDPOINT)
             - --lock_enabled=false
@@ -137,8 +140,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: ibm-vpc-block-csi-configmap
-          image: ${DRIVER_IMAGE}
-          imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
@@ -150,7 +151,6 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 3
-          name: csi-driver
           ports:
             - containerPort: 9808
               name: healthz

--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -31,6 +31,7 @@ spec:
           image: ${RESIZER_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
+            - --http-endpoint=localhost:8204
             - --v=${LOG_LEVEL}
             - --csi-address=/csi/csi.sock
             - --timeout=900s
@@ -44,10 +45,36 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        # kube-rbac-proxy for external-resizer container.
+        # Provides https proxy for http-based metrics.
+        - name: resizer-kube-rbac-proxy
+          image: ${KUBE_RBAC_PROXY_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --secure-listen-address=0.0.0.0:9204
+            - --upstream=http://127.0.0.1:8204/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --tls-cipher-suites=${TLS_CIPHER_SUITES}
+            - --tls-min-version=${TLS_MIN_VERSION}
+            - --logtostderr=true
+          ports:
+            - containerPort: 9204
+              name: resizer-m
+              protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: metrics-serving-cert
         - name: csi-provisioner
           image: ${PROVISIONER_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
+            - --http-endpoint=localhost:8202
             - --v=${LOG_LEVEL}
             - --csi-address=$(ADDRESS)
             - --timeout=600s
@@ -65,10 +92,36 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
+        # kube-rbac-proxy for external-provisioner container.
+        # Provides https proxy for http-based metrics.
+        - name: provisioner-kube-rbac-proxy
+          image: ${KUBE_RBAC_PROXY_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --secure-listen-address=0.0.0.0:9202
+            - --upstream=http://127.0.0.1:8202/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --tls-cipher-suites=${TLS_CIPHER_SUITES}
+            - --tls-min-version=${TLS_MIN_VERSION}
+            - --logtostderr=true
+          ports:
+            - containerPort: 9202
+              name: provisioner-m
+              protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: metrics-serving-cert
         - name: csi-attacher
           image: ${ATTACHER_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
+            - --http-endpoint=localhost:8203
             - --v=${LOG_LEVEL}
             - --csi-address=/csi/csi.sock
             - --timeout=900s
@@ -82,6 +135,31 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
+        # kube-rbac-proxy for external-attacher container.
+        # Provides https proxy for http-based metrics.
+        - name: attacher-kube-rbac-proxy
+          image: ${KUBE_RBAC_PROXY_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --secure-listen-address=0.0.0.0:9203
+            - --upstream=http://127.0.0.1:8203/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --tls-cipher-suites=${TLS_CIPHER_SUITES}
+            - --tls-min-version=${TLS_MIN_VERSION}
+            - --logtostderr=true
+          ports:
+            - containerPort: 9203
+              name: attacher-m
+              protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: metrics-serving-cert
         - name: liveness-probe
           image: ${LIVENESS_PROBE_IMAGE}
           imagePullPolicy: IfNotPresent
@@ -102,6 +180,7 @@ spec:
           image: ${SNAPSHOTTER_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
+            - --http-endpoint=localhost:8205
             - --v=${LOG_LEVEL}
             - --csi-address=/csi/csi.sock
             - --timeout=900s
@@ -116,10 +195,36 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
+        # kube-rbac-proxy for external-snapshotter container.
+        # Provides https proxy for http-based metrics.
+        - name: snapshotter-kube-rbac-proxy
+          image: ${KUBE_RBAC_PROXY_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --secure-listen-address=0.0.0.0:9205
+            - --upstream=http://127.0.0.1:8205/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --tls-cipher-suites=${TLS_CIPHER_SUITES}
+            - --tls-min-version=${TLS_MIN_VERSION}
+            - --logtostderr=true
+          ports:
+            - containerPort: 9205
+              name: snapshotter-m
+              protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: metrics-serving-cert
         - name: csi-driver
           image: ${DRIVER_IMAGE}
           imagePullPolicy: IfNotPresent
           args:
+            - --metrics-address=localhost:8206
             - --v=${LOG_LEVEL}
             - --endpoint=$(CSI_ENDPOINT)
             - --lock_enabled=false
@@ -165,6 +270,31 @@ spec:
             - mountPath: /etc/storage_ibmc
               name: customer-auth
               readOnly: true
+        # kube-rbac-proxy for driver container.
+        # Provides https proxy for http-based metrics.
+        - name: driver-kube-rbac-proxy
+          image: ${KUBE_RBAC_PROXY_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --secure-listen-address=0.0.0.0:9206
+            - --upstream=http://127.0.0.1:8206/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --tls-cipher-suites=${TLS_CIPHER_SUITES}
+            - --tls-min-version=${TLS_MIN_VERSION}
+            - --logtostderr=true
+          ports:
+            - containerPort: 9206
+              name: driver-m
+              protocol: TCP
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: metrics-serving-cert
       priorityClassName: system-cluster-critical
       serviceAccountName: ibm-vpc-block-controller-sa
       volumes:
@@ -173,3 +303,6 @@ spec:
         - name: customer-auth
           secret:
             secretName: storage-secret-store
+        - name: metrics-serving-cert
+          secret:
+            secretName: ibm-vpc-block-csi-driver-controller-metrics-serving-cert

--- a/assets/rbac/kube_rbac_proxy_binding.yaml
+++ b/assets/rbac/kube_rbac_proxy_binding.yaml
@@ -1,0 +1,13 @@
+# Allow kube-rbac-proxies to create tokenreviews to check Prometheus identity when scraping metrics.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ibm-vpc-block-kube-rbac-proxy-binding
+subjects:
+  - kind: ServiceAccount
+    name: ibm-vpc-block-controller-sa
+    namespace: openshift-cluster-csi-drivers
+roleRef:
+  kind: ClusterRole
+  name:  ibm-vpc-block-kube-rbac-proxy-role
+  apiGroup: rbac.authorization.k8s.io

--- a/assets/rbac/kube_rbac_proxy_role.yaml
+++ b/assets/rbac/kube_rbac_proxy_role.yaml
@@ -1,0 +1,13 @@
+# Allow kube-rbac-proxies to create tokenreviews to check Prometheus identity when scraping metrics.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name:  ibm-vpc-block-kube-rbac-proxy-role
+rules:
+  - apiGroups:
+    - "authentication.k8s.io"
+    resources:
+    - "tokenreviews"
+    verbs:
+    - "create"
+

--- a/assets/rbac/prometheus_role.yaml
+++ b/assets/rbac/prometheus_role.yaml
@@ -1,0 +1,17 @@
+# Role for accessing metrics exposed by the operator
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name:  ibm-vpc-block-csi-driver-prometheus
+  namespace: openshift-cluster-csi-drivers
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/assets/rbac/prometheus_rolebinding.yaml
+++ b/assets/rbac/prometheus_rolebinding.yaml
@@ -1,0 +1,14 @@
+# Grant cluster-monitoring access to the operator metrics service
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ibm-vpc-block-csi-driver-prometheus
+  namespace: openshift-cluster-csi-drivers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ibm-vpc-block-csi-driver-prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/assets/service.yaml
+++ b/assets/service.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: ibm-vpc-block-csi-driver-controller-metrics-serving-cert
+  labels:
+    app: ibm-vpc-block-csi-driver-controller-metrics
+  name: ibm-vpc-block-csi-driver-controller-metrics
+  namespace: openshift-cluster-csi-drivers
+spec:
+  ports:
+    - name: provisioner-m
+      port: 9202
+      protocol: TCP
+      targetPort: provisioner-m
+    - name: attacher-m
+      port: 9203
+      protocol: TCP
+      targetPort: attacher-m
+    - name: resizer-m
+      port: 9204
+      protocol: TCP
+      targetPort: resizer-m
+    - name: snapshotter-m
+      port: 9205
+      protocol: TCP
+      targetPort: snapshotter-m
+    - name: driver-m
+      port: 9206
+      protocol: TCP
+      targetPort: driver-m
+  selector:
+    app: ibm-vpc-block-csi-driver
+  sessionAffinity: None
+  type: ClusterIP

--- a/assets/servicemonitor.yaml
+++ b/assets/servicemonitor.yaml
@@ -1,0 +1,51 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ibm-vpc-block-csi-driver-controller-monitor
+  namespace: openshift-cluster-csi-drivers
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    port: provisioner-m
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    port: attacher-m
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    port: resizer-m
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    port: snapshotter-m
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    port: driver-m
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
+  jobLabel: component
+  selector:
+    matchLabels:
+      app: ibm-vpc-block-csi-driver-controller-metrics

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -2,6 +2,8 @@ package operator
 
 import (
 	"context"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/staticresourcecontroller"
 
 	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,6 +86,11 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			"csidriver.yaml",
 			"node_sa.yaml",
 			"cabundle_cm.yaml",
+			"service.yaml",
+			"rbac/prometheus_role.yaml",
+			"rbac/prometheus_rolebinding.yaml",
+			"rbac/kube_rbac_proxy_role.yaml",
+			"rbac/kube_rbac_proxy_binding.yaml",
 			"rbac/main_attacher_binding.yaml",
 			"rbac/main_provisioner_binding.yaml",
 			"rbac/volumesnapshot_reader_provisioner_binding.yaml",
@@ -132,6 +139,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			configMapInformer.Informer(),
 		},
 		csidrivercontrollerservicecontroller.WithObservedProxyDeploymentHook(),
+		csidrivercontrollerservicecontroller.WithSecretHashAnnotationHook(util.OperatorNamespace, util.MetricsCertSecretName, secretInformer),
 		csidrivercontrollerservicecontroller.WithCABundleDeploymentHook(
 			util.OperatorNamespace,
 			util.TrustedCAConfigMap,

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -183,6 +183,18 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		util.Resync,
 		controllerConfig.EventRecorder)
 
+	serviceMonitorController := staticresourcecontroller.NewStaticResourceController(
+		"IBMBlockDriverServiceMonitorController",
+		assets.ReadFile,
+		[]string{"servicemonitor.yaml"},
+		(&resourceapply.ClientHolder{}).WithDynamicClient(dynamicClient),
+		operatorClient,
+		controllerConfig.EventRecorder,
+	).WithIgnoreNotFoundOnCreate()
+
+	klog.Info("Starting ServiceMonitor controller")
+	go serviceMonitorController.Run(ctx, 1)
+
 	klog.Info("Starting the informers")
 	go kubeInformersForNamespaces.Start(ctx.Done())
 	go dynamicInformers.Start(ctx.Done())

--- a/pkg/util/const.go
+++ b/pkg/util/const.go
@@ -23,4 +23,7 @@ const (
 
 	// Name of the configmap with the injected trusted CA bundle
 	TrustedCAConfigMap = "ibm-vpc-block-csi-driver-trusted-ca-bundle"
+
+	// Name of secret that holds generated serving certificates for metrics service (defined in service.yaml and controller.yaml)
+	MetricsCertSecretName = "ibm-vpc-block-csi-driver-controller-metrics-serving-cert"
 )


### PR DESCRIPTION
cc @openshift/storage 

## Verification

### Before patch

No sidecar metric endpoints are present:
```
$ oc -n openshift-monitoring exec -ti -c prometheus prometheus-k8s-0 sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.

sh-4.4$ export token=$(cat /run/secrets/kubernetes.io/serviceaccount/token)

sh-4.4$ curl -k -H "Authorization: Bearer $token" 'https://ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc:9202/metrics'
curl: (6) Could not resolve host: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
sh-4.4$ curl -k -H "Authorization: Bearer $token" 'https://ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc:9203/metrics'
curl: (6) Could not resolve host: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
sh-4.4$ curl -k -H "Authorization: Bearer $token" 'https://ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc:9204/metrics'
curl: (6) Could not resolve host: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
sh-4.4$ curl -k -H "Authorization: Bearer $token" 'https://ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc:9205/metrics'
curl: (6) Could not resolve host: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
sh-4.4$ curl -k -H "Authorization: Bearer $token" 'https://ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc:9206/metrics'
curl: (6) Could not resolve host: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
```

### After patch

Metric endpoints are set and metric data available:
```
$ oc -n openshift-monitoring exec -ti -c prometheus prometheus-k8s-0 sh
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.

sh-4.4$ export token=$(cat /run/secrets/kubernetes.io/serviceaccount/token)

sh-4.4$ for port in {9202..9206}; do curl -k -H "Authorization: Bearer $token" "https://ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc:{$port}/metrics" | tail -n 1;done
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 34614    0 34614    0     0  1469k      0 --:--:-- --:--:-- --:--:-- 1469k
workqueue_work_duration_seconds_count{name="volumes"} 0
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 10045    0 10045    0     0   613k      0 --:--:-- --:--:-- --:--:--  613k
process_start_time_seconds 1.70904193396e+09
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  9863    0  9863    0     0   601k      0 --:--:-- --:--:-- --:--:--  601k
process_start_time_seconds 1.70904193341e+09
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  7599    0  7599    0     0   494k      0 --:--:-- --:--:-- --:--:--  494k
process_start_time_seconds 1.70904193438e+09
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  6239    0  6239    0     0   358k      0 --:--:-- --:--:-- --:--:--  358k
```

Check ServiceMonitor presence:
```
$ oc -n openshift-cluster-csi-drivers get servicemonitor/ibm-vpc-block-csi-driver-controller-monitor -o yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  creationTimestamp: "2024-02-27T13:46:26Z"
  generation: 1
  name: ibm-vpc-block-csi-driver-controller-monitor
  namespace: openshift-cluster-csi-drivers
  resourceVersion: "41925"
  uid: 121a5cb7-01c6-4d87-bead-3c7f814c82d7
spec:
  endpoints:
  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
    interval: 30s
    path: /metrics
    port: provisioner-m
    scheme: https
    tlsConfig:
      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
      serverName: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
    interval: 30s
    path: /metrics
    port: attacher-m
    scheme: https
    tlsConfig:
      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
      serverName: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
    interval: 30s
    path: /metrics
    port: resizer-m
    scheme: https
    tlsConfig:
      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
      serverName: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
    interval: 30s
    path: /metrics
    port: snapshotter-m
    scheme: https
    tlsConfig:
      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
      serverName: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
    interval: 30s
    path: /metrics
    port: driver-m
    scheme: https
    tlsConfig:
      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
      serverName: ibm-vpc-block-csi-driver-controller-metrics.openshift-cluster-csi-drivers.svc
  jobLabel: component
  selector:
    matchLabels:
      app: ibm-vpc-block-csi-driver-controller-metrics
```

![Screenshot 2024-02-27 at 16 18 06](https://github.com/openshift/ibm-vpc-block-csi-driver-operator/assets/11860179/1f82ad74-8e59-488b-971e-aac8221804fe)