### PR TITLE
OCPBUGS-33329: [ibm-vpc] Scheduling issue on IBM Cloud Bare Metal nodes

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -26,6 +26,19 @@ spec:
         # This annotation prevents eviction from the cluster-autoscaler
         cluster-autoscaler.kubernetes.io/enable-ds-eviction: "false"
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              # The region and zone labels are set on nodes by the installer based on
+              # the the platform config in install-config.yaml. ibm-vpc-block-csi-driver
+              # checks these tags during initialization and exits if they are not set.
+              # If a node is later added without these, the daemonset can not run there.
+              - key: topology.kubernetes.io/region
+                operator: Exists
+              - key: topology.kubernetes.io/zone
+                operator: Exists
       containers:
         - args:
             - --v=${LOG_LEVEL}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-33329

The daemonset pod scheduled to the baremetal node was crash looping:

```
$ oc get daemonsets -n openshift-cluster-csi-drivers
NAME                     DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
ibm-vpc-block-csi-node   7         7         6       7            6           <none>          19h

$ oc get pods -n openshift-cluster-csi-drivers
NAME                                                 READY   STATUS             RESTARTS        AGE
ibm-vpc-block-csi-controller-6f96546fb-jmwxh         6/6     Running            5 (19h ago)     20h
ibm-vpc-block-csi-driver-operator-54c877fb6c-924s5   1/1     Running            0               20h
ibm-vpc-block-csi-node-54ntr                         3/3     Running            0               20h
ibm-vpc-block-csi-node-77s75                         3/3     Running            0               19h
ibm-vpc-block-csi-node-7qkb7                         3/3     Running            0               20h
ibm-vpc-block-csi-node-8xrf8                         3/3     Running            0               19h
ibm-vpc-block-csi-node-c94qb                         3/3     Running            0               19h
ibm-vpc-block-csi-node-grxjj                         0/3     CrashLoopBackOff   16 (113s ago)   8m7s
ibm-vpc-block-csi-node-hf68k                         3/3     Running            0               20h
```

Because that node was missing region and zone tags:

`{"level":"fatal","timestamp":"2024-05-10T17:56:31.899Z","caller":"cmd/main.go:113","msg":"Failed to initialize driver...","name":"ibm-vpc-block-csi-driver","CSIDriverName":"IBM VPC block driver","error":"Controller_Helper: Failed to initialize node metadata: error: One or few required node label(s) is/are missing [failure-domain.beta.kubernetes.io/region, failure-domain.beta.kubernetes.io/zone]. Node Labels Found = [#map[beta.kubernetes.io/arch:amd64 beta.kubernetes.io/os:linux kubernetes.io/arch:amd64 kubernetes.io/hostname:rhcos1 kubernetes.io/os:linux node-role.kubernetes.io/worker: node.openshift.io/instance-type:bx2d-metal-96x384 node.openshift.io/os_id:rhcos]]"}`

The CSI driver throws the error here:

https://github.com/openshift/ibm-vpc-block-csi-driver/blob/32b4c00517de0f54bf738380064a12d58b031eec/vendor/github.com/IBM/ibm-csi-common/pkg/metadata/metadata.go#L80-L84

This PR just sets nodeAffinity to only deploy daemonset pods to nodes with the required region and zone tags.

After deploying this change on the affected cluster:

```
$ oc get daemonsets -n openshift-cluster-csi-drivers
NAME                     DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
ibm-vpc-block-csi-node   6         6         6       6            6           <none>          21h

$ oc get pods -n openshift-cluster-csi-drivers
NAME                                                READY   STATUS    RESTARTS   AGE
ibm-vpc-block-csi-controller-7d5b46cd4c-sm5rp       11/11   Running   0          12m
ibm-vpc-block-csi-driver-operator-8445f4c78-52mst   1/1     Running   0          13m
ibm-vpc-block-csi-node-gh6hx                        3/3     Running   0          12m
ibm-vpc-block-csi-node-h4slt                        3/3     Running   0          12m
ibm-vpc-block-csi-node-l6mkd                        3/3     Running   0          12m
ibm-vpc-block-csi-node-mbxts                        3/3     Running   0          12m
ibm-vpc-block-csi-node-qhl6j                        3/3     Running   0          12m
ibm-vpc-block-csi-node-r8s9q                        3/3     Running   0          12m
```

Test image with this operator change: `quay.io/jdobson/ibm-vpc-block-csi-driver-operator:bug33329-fix1`

/cc @openshift/storage
