### PR TITLE
OCPBUGS-55038: [IBM VPC] set offlineExpansion to false in e2e test manifest

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -24,6 +24,7 @@ DriverInfo:
     pvcDataSource: false
     multipods: false
     RWX: false
+    offlineExpansion: false
     controllerExpansion: true
     nodeExpansion: true
     volumeLimits: false


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-55038

With this change in the test manifest, `./openshift-tests run openshift/csi` passes:
```
55 pass, 219 skip (46m25s)
```
With these two offline expansion tests skipped:
```
skip [k8s.io/kubernetes@v1.32.2/test/e2e/storage/testsuites/volume_expand.go:196]: Driver "vpc.block.csi.ibm.io" does not support offline volume expansion - skipping  
Ginkgo exit error 3: exit with code 3

skipped: (2.2s) 2025-04-15T19:11:42 "External Storage [Driver: vpc.block.csi.ibm.io] [Testpattern: Dynamic PV (block volmode)(allowExpansion)] volume-expand Verify if offline PVC expansion works"
```
```
skip [k8s.io/kubernetes@v1.32.2/test/e2e/storage/testsuites/volume_expand.go:196]: Driver "vpc.block.csi.ibm.io" does not support offline volume expansion - skipping
Ginkgo exit error 3: exit with code 3

skipped: (2.7s) 2025-04-15T19:11:37 "External Storage [Driver: vpc.block.csi.ibm.io] [Testpattern: Dynamic PV (default fs)(allowExpansion)] volume-expand Verify if offline PVC expansion works"
```

/cherry-pick release-4.18 release-4.17 release-4.16 release-4.15 release-4.14 release-4.13 release-4.12
/cc @openshift/storage
