### PR TITLE
STOR-2330: Add labels to subscribe ibm-vpc-block CSI driver controller and node pods to NPs

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -23,6 +23,10 @@ spec:
     metadata:
       labels:
         app: ibm-vpc-block-csi-driver
+        openshift.storage.network-policy.all-egress: allow
+        openshift.storage.network-policy.api-server: allow
+        openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.metrics-range: allow
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         openshift.io/required-scc: restricted-v2

--- a/assets/network-policy-allow-ingress-to-csi-driver-metrics.yaml
+++ b/assets/network-policy-allow-ingress-to-csi-driver-metrics.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+ name: allow-ingress-to-ibm-vpc-block-metrics
+ namespace: openshift-cluster-csi-drivers
+ annotations:
+  include.release.openshift.io/hypershift: "true"
+  include.release.openshift.io/ibm-cloud-managed: "true"
+  include.release.openshift.io/self-managed-high-availability: "true"
+  include.release.openshift.io/single-node-developer: "true"
+  capability.openshift.io/name: Storage
+spec:
+ podSelector:
+   matchLabels:
+     openshift.storage.network-policy.ibm-vpc-block-metrics: allow
+ ingress:
+ - ports:
+   - protocol: TCP
+     port: 9080
+ policyTypes:
+ - Ingress

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -21,6 +21,9 @@ spec:
     metadata:
       labels:
         app: ibm-vpc-block-csi-driver
+        openshift.storage.network-policy.all-egress: allow
+        openshift.storage.network-policy.api-server: allow
+        openshift.storage.network-policy.dns: allow
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         # This annotation prevents eviction from the cluster-autoscaler

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -24,6 +24,7 @@ spec:
         openshift.storage.network-policy.all-egress: allow
         openshift.storage.network-policy.api-server: allow
         openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.ibm-vpc-block-metrics: allow
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         # This annotation prevents eviction from the cluster-autoscaler

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -118,6 +118,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			"cabundle_cm.yaml",
 			"controller_sa.yaml",
 			"node_sa.yaml",
+			"network-policy-allow-ingress-to-csi-driver-metrics.yaml",
 		},
 	).WithConditionalStaticResourcesController(
 		"IBMBlockDriverConditionalStaticResourcesController",


### PR DESCRIPTION
https://issues.redhat.com//browse/STOR-2330

This PR subscribes ibm-vpc-block CSI driver controller and driver node pods to NPs from https://github.com/openshift/cluster-storage-operator/pull/579.

NB: Unlike many other csi drivers, ibm-vpc-block CSI driver node pods don't use "hostNetwork: true". Hence they are under NPs control same way as controller pods.