### PR TITLE
STOR-2921: update deployment manifests from upstream

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -93,8 +93,8 @@ spec:
             allowPrivilegeEscalation: false
           resources:
             requests:
-              cpu: 10m
-              memory: 20Mi
+              cpu: 20m
+              memory: 40Mi
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -137,8 +137,8 @@ spec:
             allowPrivilegeEscalation: false
           resources:
             requests:
-              cpu: 10m
-              memory: 20Mi
+              cpu: 15m
+              memory: 30Mi
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -199,8 +199,8 @@ spec:
             allowPrivilegeEscalation: false
           resources:
             requests:
-              cpu: 10m
-              memory: 50Mi
+              cpu: 20m
+              memory: 40Mi
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -252,6 +252,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: MAX_VPC_RETRY_ATTEMPT
+              value: "46"
+            - name: MIN_VPC_RETRY_INTERVAL
+              value: "3"
+            - name: MIN_VPC_RETRY_INTERVAL_ATTEMPT
+              value: "3"
           envFrom:
             - configMapRef:
                 name: ibm-vpc-block-csi-configmap
@@ -272,8 +278,8 @@ spec:
               protocol: TCP
           resources:
             requests:
-              cpu: 50m
-              memory: 100Mi
+              cpu: 75m
+              memory: 150Mi
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -59,6 +59,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: VOLUME_ATTACHMENT_LIMIT
+              value: "12"
           image: ${NODE_DRIVER_REGISTRAR_IMAGE}
           imagePullPolicy: IfNotPresent
           lifecycle:
@@ -75,6 +77,7 @@ spec:
           securityContext:
             runAsNonRoot: false
             runAsUser: 0
+            runAsGroup: 0
             privileged: false
             readOnlyRootFilesystem: true
           livenessProbe:
@@ -103,6 +106,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: IS_NODE_SERVER
+              value: "true"
+            - name: SIDECAR_GROUP_ID
+              value: "2121"
+            - name: UDEVADM_SETTLE_TIMEOUT
+              value: "30"
+            - name: UDEVADM_MAX_RETRIES
+              value: "15"
+            - name: UDEVADM_RETRY_INTERVAL
+              value: "2s"
           envFrom:
             - configMapRef:
                 name: ibm-vpc-block-csi-configmap
@@ -123,11 +136,12 @@ spec:
               protocol: TCP
           resources:
             requests:
-              cpu: 20m
-              memory: 50Mi
+              cpu: 30m
+              memory: 75Mi
           securityContext:
             runAsNonRoot: false
             runAsUser: 0
+            runAsGroup: 0
             privileged: true
             readOnlyRootFilesystem: true
           volumeMounts:
@@ -159,10 +173,14 @@ spec:
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           securityContext:
-            runAsNonRoot: false
-            runAsUser: 0
+            runAsNonRoot: true
+            runAsUser: 2121
+            runAsGroup: 2121
             privileged: false
             readOnlyRootFilesystem: true
+            seLinuxOptions: # seLinux label is set as a precaution for accessing csi socket
+              type: spc_t
+              level: s0
           resources:
             requests:
               cpu: 5m


### PR DESCRIPTION
https://redhat.atlassian.net/browse/STOR-2921

This PR addresses [node](https://github.com/kubernetes-sigs/ibm-vpc-block-csi-driver/blob/v5.2.27/deploy/kubernetes/driver/kubernetes/manifests/node-server.yaml) and [controller](https://github.com/kubernetes-sigs/ibm-vpc-block-csi-driver/blob/v5.2.27/deploy/kubernetes/driver/kubernetes/manifests/controller-server.yaml) deployment manifest drift from upstream. Includes changes from https://github.com/openshift/ibm-vpc-block-csi-driver/pull/154 and previous rebases. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased CPU and memory resource requests for the storage provisioning, attachment, snapshotting, and driver components.
  * Added VPC retry configuration (attempt and timing) to improve retry behavior during transient failures.
  * Enhanced node-side settings by adding a volume attachment limit and configuring udev settle/retry timing.
  * Strengthened security contexts by adjusting group execution and applying SELinux options for the liveness probe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->