### PR TITLE
OCPBUGS-98100: e2e: increase SnapshotCreate timeout to 10m

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -30,3 +30,5 @@ DriverInfo:
     volumeLimits: false
     topology: true
     multiplePVsSameID: true
+Timeouts:
+  SnapshotCreate: 10m


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-98100

We need https://github.com/openshift/kubernetes/pull/2719 before this change will help.

/cc @openshift/storage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test settings to allow more time for snapshot creation, helping reduce timeout-related failures during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->